### PR TITLE
Skip specialization if no used types in dependency

### DIFF
--- a/src/main/java/se/kth/deptrim/core/Trimmer.java
+++ b/src/main/java/se/kth/deptrim/core/Trimmer.java
@@ -77,6 +77,10 @@ public class Trimmer {
           if (finalTrimDependencies.contains(dependencyCoordinates) && !ignoreScopes.contains(key.getScope()) && !dependencyCoordinates.equals(thisProjectCoordinates)) {
             log.info("Trimming dependency " + dependencyCoordinates);
             Set<ClassName> unusedTypes = new HashSet<>(value.getAllTypes());
+            if (value.getUsedTypes().size() == 0) {
+              log.info("Skipping specialization for bloated dependency " + dependencyCoordinates);
+              return;
+            }
             unusedTypes.removeAll(value.getUsedTypes());
             log.info(key.getFile().getName() + " -> " + unusedTypes);
             String dependencyDirName = key.getFile().getName().substring(0, key.getFile().getName().length() - 4);

--- a/src/main/java/se/kth/deptrim/core/Trimmer.java
+++ b/src/main/java/se/kth/deptrim/core/Trimmer.java
@@ -74,13 +74,12 @@ public class Trimmer {
         .forEach((key, value) -> {
           String dependencyCoordinates = key.getGroupId() + ":" + key.getDependencyId() + ":" + key.getVersion();
           // debloating only the dependencies provided by the user and if the scope is not ignored
-          if (finalTrimDependencies.contains(dependencyCoordinates) && !ignoreScopes.contains(key.getScope()) && !dependencyCoordinates.equals(thisProjectCoordinates)) {
+          if (!value.getUsedTypes().isEmpty()
+                  && finalTrimDependencies.contains(dependencyCoordinates)
+                  && !ignoreScopes.contains(key.getScope())
+                  && !dependencyCoordinates.equals(thisProjectCoordinates)) {
             log.info("Trimming dependency " + dependencyCoordinates);
             Set<ClassName> unusedTypes = new HashSet<>(value.getAllTypes());
-            if (value.getUsedTypes().size() == 0) {
-              log.info("Skipping specialization for bloated dependency " + dependencyCoordinates);
-              return;
-            }
             unusedTypes.removeAll(value.getUsedTypes());
             log.info(key.getFile().getName() + " -> " + unusedTypes);
             String dependencyDirName = key.getFile().getName().substring(0, key.getFile().getName().length() - 4);


### PR DESCRIPTION
Deptrim was generating specialized jars and corresponding poms for dependencies with no used types. We only specialize and produce poms for dependencies where number of used types is non-zero. This addresses #13.